### PR TITLE
Just a comment to build.sh to reflect that rendering here is different

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,9 @@
 #
 # Adopted from http://github.com/lzkelley/kalepy/
 #
+# But styling is different from JOSS which is also
+# rendered by github action
+#
 # Dependencies
 #  sudo apt-get install pandoc-citeproc pandoc
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Primarily to test if github action provides preview link here.  Locally invoked build.sh rendering is without any JOSS styling but github action actually renders it neatly and uploads .zip with it (kheh) to the artifacts