### PR TITLE
A pass through the paper: added section on re-execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,6 @@
 paper.pdf: paper.md paper.bib
 	datalad containers-run --explicit openjournals-paperdraft
+
+.PHONY: pandoc
+pandoc: paper.md paper.bib
+	./build.sh

--- a/paper.bib
+++ b/paper.bib
@@ -88,6 +88,14 @@
     year = {2011}
 }
 
+@misc{git-annex:projects-datalad,
+    author = {Hess, Joey and {DataLad Team}},
+    title = {git-annex: {DataLad} project - bug and todo report},
+    url = {https://git-annex.branchable.com/projects/datalad},
+    copyright = {Open Access},
+    year = {2016}
+}
+
 @misc{yoda:myyoda,
     title = {{YODA}: {README}},
     author = {{YODA Team}},
@@ -107,4 +115,34 @@
 	author = {Mark D. Wilkinson and Michel Dumontier and IJsbrand Jan Aalbersberg and Gabrielle Appleton and Myles Axton and Arie Baak and Niklas Blomberg and Jan-Willem Boiten and Luiz Bonino da Silva Santos and Philip E. Bourne and Jildau Bouwman and Anthony J. Brookes and Tim Clark and Merc{\`{e}} Crosas and Ingrid Dillo and Olivier Dumon and Scott Edmunds and Chris T. Evelo and Richard Finkers and Alejandra Gonzalez-Beltran and Alasdair J.G. Gray and Paul Groth and Carole Goble and Jeffrey S. Grethe and Jaap Heringa and Peter A.C 't Hoen and Rob Hooft and Tobias Kuhn and Ruben Kok and Joost Kok and Scott J. Lusher and Maryann E. Martone and Albert Mons and Abel L. Packer and Bengt Persson and Philippe Rocca-Serra and Marco Roos and Rene van Schaik and Susanna-Assunta Sansone and Erik Schultes and Thierry Sengstag and Ted Slater and George Strawn and Morris A. Swertz and Mark Thompson and Johan van der Lei and Erik van Mulligen and Jan Velterop and Andra Waagmeester and Peter Wittenburg and Katherine Wolstencroft and Jun Zhao and Barend Mons},
 	title = {The {FAIR} Guiding Principles for scientific data management and stewardship},
 	journal = {Scientific Data}
+}
+
+@misc{opensource:git-binary,
+    url = "https://opensource.com/life/16/8/how-manage-binary-blobs-git-part-7",
+    title = {How to manage binary blobs with Git},
+    author = {Kenlon, Seth},
+    year = {2016},
+}
+
+@article{Wittkuhn_2021,
+	doi = {10.1038/s41467-021-21970-2},
+	url = {https://doi.org/10.1038/s41467-021-21970-2},
+	year = 2021,
+	month = {mar},
+	publisher = {Springer Science and Business Media {LLC}},
+	volume = {12},
+	number = {1},
+	author = {Lennart Wittkuhn and Nicolas W. Schuck},
+	title = {Dynamics of {fMRI} patterns reflect sub-second activation sequences and reveal replay in human visual cortex},
+	journal = {Nature Communications}
+}
+
+@article{Ciric_2021,
+	doi = {10.21203/rs.3.rs-264855/v1},
+	url = {https://doi.org/10.21203/rs.3.rs-264855/v1},
+	year = 2021,
+	month = {feb},
+	publisher = {Research Square},
+	author = {Rastko Ciric and Romy Lorenz and William Thompson and Mathias Goncalves and Eilidh MacNicol and Christopher Markiewicz and Yaroslav Halchenko and Satrajit Ghosh and Krzysztof Gorgolewski and Russell Poldrack and Oscar Esteban},
+	title = {{TemplateFlow}: a community archive of imaging templates and atlases for improved consistency in neuroimaging}
 }

--- a/paper.bib
+++ b/paper.bib
@@ -95,3 +95,16 @@
     copyright = {Open Access},
     year = {2011}
 }
+
+@article{FAIR2016,
+	doi = {10.1038/sdata.2016.18},
+	url = {https://doi.org/10.1038/sdata.2016.18},
+	year = 2016,
+	month = {mar},
+	publisher = {Springer Science and Business Media {LLC}},
+	volume = {3},
+	number = {1},
+	author = {Mark D. Wilkinson and Michel Dumontier and IJsbrand Jan Aalbersberg and Gabrielle Appleton and Myles Axton and Arie Baak and Niklas Blomberg and Jan-Willem Boiten and Luiz Bonino da Silva Santos and Philip E. Bourne and Jildau Bouwman and Anthony J. Brookes and Tim Clark and Merc{\`{e}} Crosas and Ingrid Dillo and Olivier Dumon and Scott Edmunds and Chris T. Evelo and Richard Finkers and Alejandra Gonzalez-Beltran and Alasdair J.G. Gray and Paul Groth and Carole Goble and Jeffrey S. Grethe and Jaap Heringa and Peter A.C 't Hoen and Rob Hooft and Tobias Kuhn and Ruben Kok and Joost Kok and Scott J. Lusher and Maryann E. Martone and Albert Mons and Abel L. Packer and Bengt Persson and Philippe Rocca-Serra and Marco Roos and Rene van Schaik and Susanna-Assunta Sansone and Erik Schultes and Thierry Sengstag and Ted Slater and George Strawn and Morris A. Swertz and Mark Thompson and Johan van der Lei and Erik van Mulligen and Jan Velterop and Andra Waagmeester and Peter Wittenburg and Katherine Wolstencroft and Jun Zhao and Barend Mons},
+	title = {The {FAIR} Guiding Principles for scientific data management and stewardship},
+	journal = {Scientific Data}
+}

--- a/paper.md
+++ b/paper.md
@@ -15,6 +15,9 @@ authors:
  - name: Adina Wagner
    orcid: 0000-0003-2917-3450
    affiliation: 2
+#
+# Add additional authors here
+#
  - name: Michael Hanke
    orcid: 0000-0001-6398-6370
    affiliation: "2, 3"
@@ -32,32 +35,33 @@ bibliography: paper.bib
 
 # Summary
 
-The DataLad project (http://datalad.org) adapted the models of open-source software development and distribution to address technical limitations of today's data management, sharing, and provenance collection.
+The DataLad project ([datalad.org](http://datalad.org)) adapted the models of open-source software development and distribution to address technical limitations of today's data management, sharing, and provenance collection.
 Born from the idea to provide a unified data distribution for neuroscience, taking a versatile system for data logistics
-(git-annex, https://git-annex.branchable.com) built on top of the most popular distributed version control system 
-(Git, https://git-scm.com), and adopting ideas and procedures from software distributions, DataLad delivers a completely open, pioneering platform for flexible decentralized research data management (dRDM) [@Hanke_2021].
+([git-annex](https://git-annex.branchable.com)) built on top of the most popular distributed version control system 
+([Git](https://git-scm.com)), and adopting ideas and procedures from software distributions, DataLad delivers a completely open, pioneering platform for flexible decentralized research data management (dRDM) [@Hanke_2021].
 
 # Statement of Need
 
 Code, data, and computing environments are at the core of scientific practice, and unobstructed access and efficient management of all those digital objects promotes scientific discovery through collaboration, reproducibility, and replicability. 
 While software development and sharing are streamlined with the advance of software distributions, distributed version control systems, and social coding portals like GitHub, data have remained a “2nd-class citizen” in the contemporary scientific process, despite FAIR principles [@FAIR2016] postulating demands on public data hosting portals and the big callout for Data Science.
-Disconnected data hosting portals provide a cacophony of data access and authentication methods, data versioning is frequently ignored, and shared data provenance <!-- what is "shared data provenance"? --><!-- BEN: may be: data provenance - if shared at all - is often not ... --> is often not recoverable simply because data management is rarely considered to be an integral part of the scientific process.
+Disconnected data hosting portals provide a cacophony of data access and authentication methods, data versioning is frequently ignored, and data provenance - if shared at all - is often not recoverable simply because data management is rarely considered to be an integral part of the scientific process.
 <!-- MIH summary: inconvenient access, version/provenenance information unavailable -->
-DataLad aims to solve these issues by streamlining data consumption, publication, and updating routines, by providing a simplified core API <!--BEN: s/core API/interface/ while I don't mind using "API" internally I don't think it's appropriate in a publication. It's just an interface, not really an application programming interface. --> for Git and git-annex operations, and by providing additional features for reproducible science such as command execution provenance capturing and automatic recomputation based on complete process provenance.
-Since it is interoperable with a large variety of scientific and commercial hosting services and available for all operating systems,
-DataLad can be integrated into established systems with minimal adjustments.
+DataLad aims to solve these issues by streamlining data consumption, publication, and updating routines, by providing simplified core interfaces for Git and git-annex operations, and by providing additional features for reproducible science such as command execution provenance capturing and making re-execution possible.
+Since it is interoperable with a large variety of scientific and commercial hosting services and available for all operating systems, DataLad can be integrated into established systems with minimal adjustments.
 
 ## Why Git and git-annex
 
-Git is an excellent <!-- citation needed -->distributed content management system geared towards managing and collaborating on text files <!-- citation needed, does not match self-description -->, but it is not designed to handle large (e.g., over a gigabyte) or binary files efficiently.
-Moreover, any data committed to Git becomes available to all clones of that repository. In the context of scientific data, this makes it hard or impossible to provide distributed storage of managed data <!-- why? individual tailoring is hard, but distribution not, what is special about scientific data in this regard? -->, or revoke individual files <!-- this somewhat suggests, that with datalad one can easily revoke, which at least requires a clarification of that does and doesn't mean -->, such as accidentally stored personal data or data from participants that withdrew from a study.
-Git-annex takes advantage of Git's ability to manage textual information to overcome Git's limitation in managing individual file content that is either large or sensitive.
-File content managed by git-annex is placed into an annex, and in its place, git-annex commits a link (a symbolic link or a git link) pointing to the content of the file into Git.
+Git is an excellent <!-- citation needed -->distributed content management system geared towards managing and collaborating on text files <!-- citation needed, does not match self-description -->, but it is not designed to handle large (e.g., over a gigabyte) or binary files efficiently [see e.g. @opensource:git-binary].
+<!-- YOH: I do not think we need citation to support ever statement, especially for which there would be no scholary articly "deeply investigating" it.  Added a citation to some first hit on google -->
+Moreover, any data committed to Git becomes available to all clones of that repository.
+This makes it hard or impossible to provide distributed storage of managed data <!-- why? individual tailoring is hard, but distribution not, what is special about scientific data in this regard? YOH: "distributed storage" != "distribution". Removed "scientic data" preamble and otherwise I think this statement is ok otherwise-->, or stop providing some individual files, such as accidentally stored personal data or data from participants that withdrew from a study.
+Git-annex takes advantage of Git's ability to efficiently manage textual information to overcome Git's limitation in managing individual file content that is either large or sensitive.
+File content managed by git-annex is placed into an annex, and in its place, git-annex commits a link (a symbolic link or a git link) pointing to the content of the file.
 The content representation is based on a checksum of the file's content.
 As such, while only a light-weight link is directly committed into Git, this committed information contains the content identity of annexed files.
-Git-annex then manages files availability information in any local repository, other Git remotes, or external resources, e.g. web urls.
-Having that information, git-annex takes care of all transport logistics to exchange data upon user request.
-Such simple approach allows git-annex to scale to manage and version control virtually arbitrarily large files, and "link" files in a Git repository to vast data resources available online.
+Git-annex then manages content availability information in any local repository, other Git remotes, or external resources, e.g. web urls.
+Having that information, git-annex takes care of all transport logistics to exchange content upon user request.
+Such simple approach allows git-annex to manage and version control virtually arbitrarily large files, and "link" files in a Git repository to vast data resources available online.
 <!-- BEN thinks we need to make explicit the idea, that by means of how annex
 works, the content and access control to it is separated from the version
 control (and metadata). ATM this follows implicitly but may be much less obvious
@@ -70,36 +74,61 @@ to someone who didn't dive into it yet -->
 
 **They are generic and might lack support for domain specific solutions.** 
 Git can interact with other repositories on the file system or accessible via a set of standard (ssh, http) or custom (Git) network transport protocols.
-Interaction with non git-aware portals should then be implemented via custom Git transfer protocols, as it e.g. was done in datalad-osf [@datalad-osf:zenodo].
+Interaction with non git-aware portals should then be implemented via custom Git transfer protocols, as e.g. it was done in datalad-osf [@datalad-osf:zenodo].
 Git-annex provides access to a wide range of external data storage resources via various protocols, but cannot implement all idiosyncracies of any individual data portal.
-In particular, scientific data is frequently stored in compressed archives to reduce its storage demands, or on specialized servers, such as XNAT (www.xnat.org).
-To address these demands, git-annex implemented support for external special remotes by establishing a protocol [@git-annex:special_remotes_protocol] through which external tools can provide custom transport functionality transparently to the user.
+In particular, scientific data is frequently stored in compressed archives to reduce its storage demands, and/or on specialized servers, such as XNAT ([www.xnat.org](http://www.xnat.org)).
+To address these demands, git-annex established a protocol [@git-annex:special_remotes_protocol] through which external tools can provide custom transport functionality transparently to the git-annex user.
 This allowed DataLad and many other projects to facilitate access to an ever growing collection of resources [@git-annex:special_remotes] and to overcome technological limitations (e.g., maximal file sizes, or file system inodes limits).
 
 **They require a layer above to establish a *distribution*.**
-The DataLad project's initial goal was to provide a data distribution with unified access to the already available public data archives in neuroscience, such as http://crcns.org or http://openfmri.org.
-Git and git-annex are just "client tools" and do not provide aggregation of different resources into a unified distribution on their own.
-http://datasets.datalad.org became an example of such a data distribution curated by the DataLad team, which at the moment provides streamlined access to over 250 TBs of data across wide range of projects and archives.
-<!-- MIH thinks this needs a clarification of terms. If datasets.d.o is a distribution than datalad is "just a client tool" too. I think this is probably aimed at the nesting feature, and if so, we should use the term, because people can read about it in the handbook. This technical feature is then what is used to build a "unified data distribution"-->
+The DataLad project's initial goal was to provide a data distribution with unified access to already available public data archives in neuroscience, such as [crcns.org](http://crcns.org) and [openfmri.org](http://openfmri.org).
+On their own, Git and git-annex do not provide user interfaces for search across available repositories or for convenient manipulation of individual components of a data distribution. 
+[datasets.datalad.org](http://datasets.datalad.org) became an example of such a data distribution curated by the DataLad team, which at the moment provides streamlined access to over 250 TBs of data across wide range of projects and archives.
+<!-- MIH thinks this needs a clarification of terms. If datasets.d.o is a distribution than datalad is "just a client tool" too. I think this is probably aimed at the nesting feature, and if so, we should use the term, because people can read about it in the handbook. This technical feature is then what is used to build a "unified data distribution" -->
+<!-- YOH: good point, after all every distribution relies on client tools.  I have tried to address it above by removing the notion of "just a client tool".
+ I do not think we can escape "metadata" completely -->
 <!-- BEN adds to MIH: below we call ds.dl.org a testament of scalability, and
 this is what I think it is. A showcase, not somehow a central or special part of
 DataLad itself. Therefore I'd present it as the conclusion of what that
 modularization allows for. Overall the "additional layer" the headline talks
 about is not clear to me.-->
+<!-- YOH: IMHO modularization is IMHO a very related but different aspect from "distribution"
+ which is largely about bringing components from different resources together under a unified interface,
+ with mechanisms to declare relationships (dependencies), often versioning, and then some notion of convenient URIs (package names vs urls).
+ Any distribution indeed needs some level of modularization.
+ As those are two aspects are very related, order could be swapped, but then we would need to re-work out "cross-referencing" -->
 
 **Modularization is needed to scale.**
 Research workflows impose additional demands for an efficient research data management (RDM) platform besides "version control" and "data transport".
 Many research datasets contain millions of files, and that precludes placing such datasets in their entirety within a single Git repository even if individual files are tiny in their size.
 Such datasets should be partitioned into smaller subdatasets (e.g., a subdataset per each subject in the dataset comprising thousands of participants).
-This modularization allows for not only scalable management <!-- unclear how management of 10k small pieces becomes more scalable than one piece with 10k parts -->, but also for the efficient reuse of a selected subset of datasets.
+This modularization allows for not only scalable management, <!-- unclear how management of 10k small pieces becomes more scalable than one piece with 10k parts; YOH: just by virtue of being able to handle 10k * 10k files --> but also for the efficient reuse of a selected subset of datasets.
 DataLad uses Git's submodule mechanism to unambiguously link (versions of) individual datasets into larger super-datasets, and further simplifies working with the resulting hierarchies of datasets with recursive operations across dataset boundaries.
 <!-- BEN: There are more aspect of modularization than reuse and large-scale.
 Most importantly, that's the notions of dependencies and a derivative
-relationsship that can be expressed that way, I think. --> 
+relationsship that can be expressed that way, I think. -->
+<!-- YOH: well, there is "unambiguously link (versions of) " in above.  Could indeed be elaborated -->
 With this, DataLad makes it trivial to operate on individual files deep in the hierarchy or entire sub-trees of datasets, providing a "mono-repo"-like user experience in datasets nested arbitrarily deep.
-<!-- modularization is presented as #2, but it seems to be just #1 (nesting) described from a different angle -->
+<!-- MIH: modularization is presented as #2, but it seems to be just #1 (nesting) described from a different angle -->
+<!-- YOH: not sure what #2 here, since in above it is "reproducible execution" in "MIH thinks:".
 
-**They do not necessarily facilitate the best scientific workflow.**
+As for #2 "reproducible execution" - I think we missed such subsection entirely, so I added it:
+--> 
+
+**Annotation of changes is not "re-executable".**
+Git commit message is a freeform text intended to be used to provide a human-readable description of introduced changes.
+Changes themselves are typically represented by a patch (an exact difference between two versions) which could be re-used and applied to another version of the text file(s). 
+Such changes annotation is not sufficient to introduce such changes following the description if they cannot be completely represented by such a patch.
+<!-- YOH: may be strip above sentence away... I am just trying to lead somehow into "semantic" description of the change.
+  E.g. that if author was very good with the description of change, some smart AI could have redone it following the description
+  and not the patch.  The simplest analog could be "replaced word X with Y" where the patch would contain exact difference, but
+  either will not be applicable or just would miss some Xs if applied to a vastly different version -->
+Unlike changes to text documents or source code typically done "manually", data manipulations are most often performed by software.
+DataLad exploits this fact and enables automated annotation of changes which result from running an external command.
+DataLad creates a commit message which does not only include a human-readable summary, but also a human and machine-readable record of the command invocation which introduced the changes.
+This allows for the data "change" to be re-executed to either verify that results reproduce, or to apply such a "change" to a completely different state. 
+
+**Git and it-annex do not necessarily facilitate the best scientific workflow.**
 Git and git-annex, being generic tools, come with rich interfaces and allow for a wide range of workflows.
 DataLad strives to provide a higher level interface to more efficiently cover typical use cases encountered in the scientific practice than the direct invocation of individual Git and git-annex commands, and to encourage efficient computation and reproducible workflows.
 To this end, DataLad is also accompanied by rich documentation [@datalad-handbook:zenodo] to guide a scientist of any technological competency level, and agnostic of the field of science.
@@ -110,16 +139,16 @@ To this end, DataLad is also accompanied by rich documentation [@datalad-handboo
 ## DataLad core
 
 The `datalad` Python package provides both a Python library and a command line tool which expose core DataLad functionality to fulfill a wide range of dRDM use cases for any domain.
-Its API (see \autoref{fig:one}) operates on DataLad datasets which are just Git (with optional git-annex for data) repositories with additional metadata and configuration.
+DataLad (see \autoref{fig:one}) operates on DataLad datasets which are just Git (with optional git-annex for data) repositories with additional metadata and configuration.
  
 ![DataLad: overview of available commands for various parts of the data management process \label{fig:one}](figures/datalad_process.png)
 
 Using Git's submodules mechanism, DataLad embraces and simplifies modular composition of smaller datasets into larger (super)datasets.
-With this simple paradigm, DataLad fulfills the YODA principles for reproducible science [@yoda:myyoda] and facilitates efficient access, composition, scalability, reuse, sharing, and reproducibility of results  (see Figure 2).
+With this simple paradigm, DataLad fulfills the YODA principles for reproducible science [@yoda:myyoda] and facilitates efficient access, composition, scalability, reuse, sharing, and reproducibility of results  (see \autoref{fig:two}).
 
-![DataLad datasets all the way down: from publication to raw data](figures/datalad-nesting-access.png)
+![DataLad datasets all the way down: from publication to raw data \label{fig:two}](figures/datalad-nesting-access.png)
 
-As a testament of scalability, http://datasets.datalad.org provides a DataLad (super)dataset encapsulating thousands of datasets and providing unified access to over 250 TBs of primarily neural data from a wide range of hosting portals. 
+As a testament of scalability, [datasets.datalad.org](http://datasets.datalad.org) provides a DataLad (super)dataset encapsulating thousands of datasets with unified access to over 250 TBs of primarily neural data from a wide range of hosting portals.
 
 ## Extensions
 
@@ -128,24 +157,25 @@ To harmoniously extend its functionality, DataLad provides mechanism for providi
 Some exemplar extensions include:
 
 - [datalad-container](https://github.com/datalad/datalad-container) [@datalad-container:zenodo] to simplify management and use of Docker and Singularity containers typically containing complete computational environments;
-- [datalad-crawler](https://github.com/datalad/datalad-crawler) [@datalad-crawler:zenodo] the functionality which initiated the DataLad project - support for creating and updating DataLad datasets from external resources;
-- [datalad-neuroimaging](https://github.com/datalad/datalad-neuroimaging) [@datalad-neuroimaging:zenodo] to provide neuroimaging specific procedures and metadata extractors
+- [datalad-crawler](https://github.com/datalad/datalad-crawler) [@datalad-crawler:zenodo] the functionality which initiated the DataLad project - to automate creation and updates of DataLad datasets from external resources;
+- [datalad-neuroimaging](https://github.com/datalad/datalad-neuroimaging) [@datalad-neuroimaging:zenodo] to provide neuroimaging specific procedures and metadata extractors;
 - [datalad-osf](https://github.com/datalad/datalad-osf/) [@datalad-osf:zenodo] to collaborate using DataLad through the Open Science Framework (OSF).
 
-The same mechanism of extensions is used for rapid development of new functionality to later be moved into the main DataLad codebase 
-(e.g., [datalad-metalad](https://github.com/datalad/datalad-metalad/)).
-https://github.com/datalad/datalad-extensions/ repository provides a list of extensions and contineous integration testing of their released versions against released and development versions of the DataLad core. 
-A premade template (https://github.com/datalad/datalad-extension-template) can be used for creating new DataLad extensions.
+The same mechanism of extensions is used for rapid development of new functionality to later be moved into the main DataLad codebase (e.g., [datalad-metalad](https://github.com/datalad/datalad-metalad/)).
+[datalad-extensions](https://github.com/datalad/datalad-extensions/) repository provides a list of extensions and contineous integration testing of their released versions against released and development versions of the DataLad core. 
+[datalad-extension-template](https://github.com/datalad/datalad-extension-template) template repository can be used for creating new DataLad extensions.
 
 ## External uses and integrations
 
-TODO: probably here cite some examples of scientific papers in the wild which used DataLad
+[comment1]: <> (TODO: probably here cite some examples of scientific papers in the wild which used DataLad)
 
-DataLad can be used as an independent tool, or as a core technology behind a larger platform.
+DataLad can be used as an independent tool as it used by scientists to access and/or manage data (see e.g. @Wittkuhn_2021),
+or as a core technology behind another tool or a larger platform.
+[TemplateFlow](http://templateflow.github.io/) [@Ciric_2021] uses DataLad for the management of existing and orchestration of new submissions of neuroimaging templates.
 [OpenNeuro](http://openneuro.org) uses DataLad for data logistics with data deposition to a public S3 bucket.
 [CONP-PCNO](https://github.com/CONP-PCNO/) adopts aforementioned modular composition to deliver a rich collection of datasets with public or restricted access to data.
 [ReproMan](http://reproman.repronim.org) integrates with DataLad to provide version control and data logistics.
-https://www.datalad.org/integrations.html provides a more complete list of DataLad usage and integration with other projects, and @Hanke_2021 provides a systematic depiction of DataLad as a dRDM used by a number of projects. 
+[www.datalad.org/integrations.html](https://www.datalad.org/integrations.html) provides a more complete list of DataLad usage and integration with other projects, and @Hanke_2021 provides a systematic depiction of DataLad as a dRDM used by a number of projects. 
 
 
 ## Documentation
@@ -153,9 +183,9 @@ https://www.datalad.org/integrations.html provides a more complete list of DataL
 The DataLad core repository populates [docs.datalad.org](http://docs.datalad.org/en/latest/) with developer-oriented information and detailed descriptions of command line and Python interfaces.
 A comprehensive [DataLad Handbook](http://handbook.datalad.org) [@datalad-handbook:zenodo] provides documentation with numerous usage examples oriented toward novice and advanced users of all backgrounds.
 
-The simplest "prototypical" example is `datalad search haxby` which would install the http://datasets.datalad.org superdataset, and search for datasets mentioning `haxby` anywhere in their metadata records.
+The simplest "prototypical" example is `datalad search haxby` which would install the [datasets.datalad.org](http://datasets.datalad.org) superdataset, and search for datasets mentioning `haxby` anywhere in their metadata records.
 Any reported dataset could be immediately installed using `datalad install` command, and data files of interest obtained using `datalad get`.
-More use-case driven examples could be found in [@datalad-handbook:use-cases].
+More use-case driven examples could be found in the [handbook](http://handbook.datalad.org/en/latest/usecases/intro.html) [@datalad-handbook:use-cases].
 
 ## Installation
 
@@ -165,22 +195,20 @@ The [datalad-installer](https://github.com/datalad/datalad-installer/) (also ava
 
 ## Development
 
-DataLad is being developed openly in a public repository (https://github.com/datalad/datalad) since its inception in 2013.
+DataLad is being developed openly in a public repository ([github.com/datalad/datalad](https://github.com/datalad/datalad)) since its inception in 2013.
 At the time of this publication, the repository amassed over 13.5k commits, 2.5k merged PRs, and 2.3k closed (+700 open) issues from over 30 contributors.
 Issue tracker, labels, milestones, and pull requests (from personal forks) are used to coordinate development.
 DataLad heavily relies on the versatility and stability of the underlying core tools - Git and git-annex.
-To avoid reimplementing the wheel and to benefit the git-annex user community at large, many aspects of the desired functionality are and have been implemented directly in git-annex through collaboration with the git-annex developer Joey Hess (see https://git-annex.branchable.com/projects/datalad).
-To guarantee robust operation across various deployments DataLad heavily utilizes continuous integration platforms (Appveyor, GitHub actions, and Travis CI) for testing DataLad core, building and testing git-annex (in a dedicated https://github.com/datalad/git-annex), and integration testing 
-with DataLad extensions (https://github.com/datalad/datalad-extensions/).
+To avoid reimplementing the wheel and to benefit the git-annex user community at large, many aspects of the desired functionality are and have been implemented directly in git-annex through collaboration with the git-annex developer Joey Hess [@git-annex:projects-datalad].
+To guarantee robust operation across various deployments DataLad heavily utilizes continuous integration platforms (Appveyor, GitHub actions, and Travis CI) for testing DataLad core, building and testing git-annex (in a dedicated [github.com/datalad/git-annex](https://github.com/datalad/git-annex)), and integration testing 
+with DataLad extensions ([datalad-extensions](https://github.com/datalad/datalad-extensions/)).
 
 ## Contributions
 
 DataLad is released under DFSG- and OSI-compliant MIT/Expat license, and license terms for reused in the code-base components are provided in the [COPYING](https://github.com/datalad/datalad/blob/master/COPYING) file.
 [CONTRIBUTING.md](https://github.com/datalad/datalad/blob/master/CONTRIBUTING.md) file shipped within DataLad's source repository provides guidelines for submitting contributions.
 
-# Author Contributions
-
-if desired/needed -- or drop altogether.
+[comment2]: <> (# Author Contributions: if desired/needed -- or drop altogether.)
 
 # Conflicts of interest
 
@@ -188,13 +216,19 @@ There are no conflicts to declare.
 
 # Acknowledgements
 
-DataLad development was facilitated by a senior adviser Dr. James V. Haxby (Dartmouth College), and made possible thanks to support by
+DataLad development was facilitated by a senior adviser Dr. James V. Haxby (Dartmouth College).
+It was made possible thanks to support by 
 NSF [1429999](http://www.nsf.gov/awardsearch/showAward?AWD_ID=1429999), 
 [1912266](http://www.nsf.gov/awardsearch/showAward?AWD_ID=1912266) 
 (PI: Halchenko) and BMBF 01GQ1411 and 01GQ1905 (PI: Hanke) 
 through [CRCNS](https://www.nsf.gov/funding/pgm_summ.jsp?pims_id=5147) program.
 It received significant contributions from ReproNim [1P41EB019936-01A1](https://projectreporter.nih.gov/project_info_details.cfm?aid=8999833&map=y) and DANDI [5R24MH117295-02](https://projectreporter.nih.gov/project_info_description.cfm?aid=9981835&icde=53349087) NIH projects. ... .
-We would also like to express our gratitude to [TODOADD: contributors not among co-authors]... for the contributions to the codebase, and [TODOADD: notable contributors to issues] for filing bug reports and recommendations.
+
+We would also like to express our gratitude to 
+[TODOADD: contributors not among co-authors]... 
+for the contributions to the codebase, and 
+[TODOADD: notable contributors to issues]
+for filing informative bug reports and recommendations.
 
 
 # References

--- a/paper.md
+++ b/paper.md
@@ -18,6 +18,8 @@ authors:
 #
 # Add additional authors here
 #
+# and leave M.Hanke to be the senior
+#
  - name: Michael Hanke
    orcid: 0000-0001-6398-6370
    affiliation: "2, 3"

--- a/paper.md
+++ b/paper.md
@@ -40,10 +40,8 @@ Born from the idea to provide a unified data distribution for neuroscience, taki
 # Statement of Need
 
 Code, data, and computing environments are at the core of scientific practice, and unobstructed access and efficient management of all those digital objects promotes scientific discovery through collaboration, reproducibility, and replicability. 
-While software development and sharing are streamlined with the advance of software distributions, distributed version control systems, and social coding portals like GitHub, data have remained a “2nd-class citizen” in the contemporary scientific process, despite FAIR principles postulating demands on public data hosting portals and the big callout for Data Science.
-<!-- citation needed, no idea what the big callout is, or how/where FAIR calls for
-public data hosting -->
-Disconnected FAIR<!-- the use of FAIR here confuses, it comes across as a blame--> data hosting portals provide a cacophony of data access and authentication methods, data versioning is frequently ignored, and shared data provenance <!-- what is "shared data provenance"? --><!-- BEN: may be: data provenance - if shared at all - is often not ... --> is often not recoverable simply because data management is rarely considered to be an integral part of the scientific process.
+While software development and sharing are streamlined with the advance of software distributions, distributed version control systems, and social coding portals like GitHub, data have remained a “2nd-class citizen” in the contemporary scientific process, despite FAIR principles [@FAIR2016] postulating demands on public data hosting portals and the big callout for Data Science.
+Disconnected data hosting portals provide a cacophony of data access and authentication methods, data versioning is frequently ignored, and shared data provenance <!-- what is "shared data provenance"? --><!-- BEN: may be: data provenance - if shared at all - is often not ... --> is often not recoverable simply because data management is rarely considered to be an integral part of the scientific process.
 <!-- MIH summary: inconvenient access, version/provenenance information unavailable -->
 DataLad aims to solve these issues by streamlining data consumption, publication, and updating routines, by providing a simplified core API <!--BEN: s/core API/interface/ while I don't mind using "API" internally I don't think it's appropriate in a publication. It's just an interface, not really an application programming interface. --> for Git and git-annex operations, and by providing additional features for reproducible science such as command execution provenance capturing and automatic recomputation based on complete process provenance.
 Since it is interoperable with a large variety of scientific and commercial hosting services and available for all operating systems,
@@ -72,7 +70,7 @@ to someone who didn't dive into it yet -->
 
 **They are generic and might lack support for domain specific solutions.** 
 Git can interact with other repositories on the file system or accessible via a set of standard (ssh, http) or custom (Git) network transport protocols.
-Interaction with non git-aware portals should then be implemented via custom Git transfer protocols, as it e.g. was done in datalad-osf [TODOREF].
+Interaction with non git-aware portals should then be implemented via custom Git transfer protocols, as it e.g. was done in datalad-osf [@datalad-osf:zenodo].
 Git-annex provides access to a wide range of external data storage resources via various protocols, but cannot implement all idiosyncracies of any individual data portal.
 In particular, scientific data is frequently stored in compressed archives to reduce its storage demands, or on specialized servers, such as XNAT (www.xnat.org).
 To address these demands, git-annex implemented support for external special remotes by establishing a protocol [@git-annex:special_remotes_protocol] through which external tools can provide custom transport functionality transparently to the user.


### PR DESCRIPTION
    - addressed some comments,
    - replied to other comments
    - added initial version of re-execution section in "why not git/git-annex"
    - added a few more references
    - added placeholder for placement of additional authors
    - unified URLs a bit to have them as hyperlinks and to not
      occlude text too much

Filing as a PR to ease review of this set of changes, but will merge shortly after so others could introduce changes on top, unless immediate discussion etc would happen right here in PR.