### PR TITLE
Ensure having and harmonize affiliations

### DIFF
--- a/paper.md
+++ b/paper.md
@@ -24,6 +24,7 @@ authors:
    orcid: 0000-0003-2917-3450
    affiliation: 2
  - name: Jason Gors  # 60 commits, issues: opened 2 participated in 1
+   affiliation: 1
  - name: Dave MacFarlane  # 30 commits, issues: opened 4 participated in 4
    affiliation: 14 # add full names if not yet listed, or indexes if already are
  - name: Dorian Pustina  # 0 commits, issues: opened 30 participated in 5
@@ -103,35 +104,36 @@ authors:
    affiliation: "6"
  - name: Robin Schneider  # 1 commits, issues: opened 1 participated in 1
    orcid: 0000-0003-1952-5459
+   affiliation: 19
  - name: Michael Hanke^[co-first author]  # 4158 commits, issues: opened 1097 participated in 780
    orcid: 0000-0001-6398-6370
    affiliation: "2, 3"
 affiliations:
- - name: Dartmouth College, Hanover, NH, United States
+ - name: Center for Open Neuroscience, Department of Psychological and Brain Sciences, Dartmouth College, Hanover, NH, USA
    index: 1
  - name: Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany
    index: 2
  - name: Institute of Systems Neuroscience, Medical Faculty, Heinrich Heine University Düsseldorf, Düsseldorf, Germany
    index: 3
- - name: Lawrence Livermore National Lab, Livermore, CA, United States
+ - name: Lawrence Livermore National Lab, Livermore, CA, USA
    index: 4
- - name: McGill University, Faculty of Medicine and Health Sciences, McConnell Brain Imaging Centre, Montreal, Canada
+ - name: Faculty of Medicine and Health Sciences, McConnell Brain Imaging Centre, McGill University, Montreal, Canada
    index: 5
- - name: Department of Biological Engineering, Massachusetts Institute of Technology, Cambridge, United States of America
+ - name: Department of Biological Engineering, Massachusetts Institute of Technology, Cambridge, USA
    index: 6
  - name: CHDI Management/CHDI Foundation, Princeton, NJ, USA
    index: 7
- - name: University of Oslo
+ - name: University of Oslo, Oslo, Norway
    index: 8
- - name: Stanford University, Stanford, CA, United States
+ - name: Stanford University, Stanford, CA, USA
    index: 9
- - name: The University of Austin at Austin, Austin, TX, United States
+ - name: The University of Austin at Austin, Austin, TX, USA
    index: 10
- - name: Massachusetts Institute of Technology, Cambridge, MA, United States
+ - name: Massachusetts Institute of Technology, Cambridge, MA, USA
    index: 11
  - name: Department of Biological Psychology, Otto-von-Guericke-University Magdeburg, Magdeburg, Germany
    index: 12
- - name: Indiana University
+ - name: Indiana University, Bloomington, IN, USA
    index: 13
  - name: McGill Centre for Integrative Neuroscience, Montreal, Canada
    index: 14
@@ -139,10 +141,12 @@ affiliations:
    index: 15
  - name: University of Pennsylvania, Philadelphia, PA
    index: 16
- - name: University of Massachusetts Medical School, Worcester, MA, United States
+ - name: University of Massachusetts Medical School, Worcester, MA, USA
    index: 17
- - name: Quest Diagnostics, Marlborough, MA, United States
+ - name: Quest Diagnostics, Marlborough, MA, USA
    index: 18
+ - name: Independent Developer, Germany
+   index: 19
 date: 24 March 2021
 bibliography: paper.bib
 


### PR DESCRIPTION
According to https://github.com/openjournals/joss/issues/783 there is still
"room for improvement" with affiliations and there is no option for no affiliation AFAIK.
So I did specify 1 for J Gors since work he did was accomplised at CON, and it would
be inline with existing entry for Debanjum -- they are forever affiliated with CON
(even if only as emeritus).

Then I provided "Independent Developer, Germany" for @ypid-geberit (please suggest a better
one if you like).

I used USA instead of United States as was exampled in aforementioned issue, and otherwise
tried to harmonize them.  Closes #51

Making it into a PR but will merge shortly to avoid possible conflicts, please comment on or submit a PR if further tune up is needed